### PR TITLE
Copy all attributes from original road to the new road after the split.

### DIFF
--- a/Scripts/Split Intersecting Road (1 Update, 1 Add).js
+++ b/Scripts/Split Intersecting Road (1 Update, 1 Add).js
@@ -107,21 +107,21 @@ for (var road in intersectingRoads) {
 		// Store an add for a new road with the second geometry from the cut and the new right from and left from value 
         var newId = "RD-" + NextSequenceValue("CenterlineID");
         var featureAttributes = Dictionary(Text(road))['attributes'];
-		var newAttributes = {};
-		for(var k in featureAttributes) {
-			if (IndexOf(["globalid", "objectid", "shape_length", "shape_area"], Lower(k)) > -1) {
-				continue;
-			}
-			else if (Lower(k) == "fromright") {
-				newAttributes['fromright'] = newToFromRight[1];
-			}
-			else if (Lower(k) == "fromleft") {
-				newAttributes['fromleft'] = newToFromLeft[1];
-			}
-			else {
-				newAttributes[k] = featureAttributes[k];
-			}
+	var newAttributes = {};
+	for(var k in featureAttributes) {
+		if (IndexOf(["globalid", "objectid", "shape_length", "shape_area"], Lower(k)) > -1) {
+			continue;
 		}
+		else if (Lower(k) == "fromright") {
+			newAttributes['fromright'] = newToFromRight[1];
+		}
+		else if (Lower(k) == "fromleft") {
+			newAttributes['fromleft'] = newToFromLeft[1];
+		}
+		else {
+			newAttributes[k] = featureAttributes[k];
+		}
+	}
         adds[Count(adds)] = {
              'attributes': newAttributes,
              'geometry': secondGeometry

--- a/Scripts/Split Intersecting Road (1 Update, 1 Add).js
+++ b/Scripts/Split Intersecting Road (1 Update, 1 Add).js
@@ -106,10 +106,24 @@ for (var road in intersectingRoads) {
 		// Create a new id for a road
 		// Store an add for a new road with the second geometry from the cut and the new right from and left from value 
         var newId = "RD-" + NextSequenceValue("CenterlineID");
+        var featureAttributes = Dictionary(Text(road))['attributes'];
+		var newAttributes = {};
+		for(var k in featureAttributes) {
+			if (IndexOf(["globalid", "objectid", "shape_length", "shape_area"], Lower(k)) > -1) {
+				continue;
+			}
+			else if (Lower(k) == "fromright") {
+				newAttributes['fromright'] = newToFromRight[1];
+			}
+			else if (Lower(k) == "fromleft") {
+				newAttributes['fromleft'] = newToFromLeft[1];
+			}
+			else {
+				newAttributes[k] = featureAttributes[k];
+			}
+		}
         adds[Count(adds)] = {
-             'attributes': {'centerlineid' : newId, 'roadclass' : road.roadclass, 'fullname' : road.fullname,
-                            'fromright' : newToFromRight[1], 'fromleft' : newToFromLeft[1], 'toright' : toRight, 'toleft' : toLeft
-             },
+             'attributes': newAttributes,
              'geometry': secondGeometry
         }
         


### PR DESCRIPTION
@MikeMillerGIS, @pLeBlanc93, I found at 1.8 they added a new additional signature to the dictionary function that allows you to parse json text to create a dictionary. So this allows me now to do something like below to get the attributes of a feature as a dictionary.

 Dictionary(Text($feature))['attributes']

This partially solved my need to add a new feature that had all the same attributes as another as part of my split operation. The annoying thing is any fields that are not editable (ObjectID, GlobalID. Shape fields) have to be removed from the dictionary otherwise an error is thrown. Would prefer that they just get ignored. But below is my code to work around this for now. Worry this won't work well in different DBMS however as these system fields may change.

Any suggestions?